### PR TITLE
Upgrade dependencies

### DIFF
--- a/Heroes.Graphics.Essentials/GraphicsEssentials.cs
+++ b/Heroes.Graphics.Essentials/GraphicsEssentials.cs
@@ -91,7 +91,7 @@ public class GraphicsEssentials
         _resolutionVariablePatcher.SubscribeToResizeEventHook(_resizeEventHook);
         _renderHooks.SubscribeToResizeEventHook(_resizeEventHook);
 
-        while (User32.GetMessage(out var msg, HWND.NULL, 0, 0))
+        while (User32.GetMessage(out var msg, HWND.NULL, 0, 0) > 0)
         {
             User32.TranslateMessage(msg);
             User32.DispatchMessage(msg);

--- a/Heroes.Graphics.Essentials/Heroes.Graphics.Essentials.csproj
+++ b/Heroes.Graphics.Essentials/Heroes.Graphics.Essentials.csproj
@@ -42,9 +42,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reloaded.Mod.Interfaces" Version="2.3.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Reloaded.Mod.Interfaces" Version="2.4.0" ExcludeAssets="runtime" />
     <PackageReference Include="Reloaded.SharedLib.Hooks" Version="1.9.0" />
-    <PackageReference Include="Vanara.PInvoke.User32" Version="3.4.9" />
+    <PackageReference Include="Vanara.PInvoke.User32" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Vanara.PInvoke.User32 major version change results in int instead of bool for User32 call; 0 = equivalent behavior for false